### PR TITLE
fix: stabilize release validation and Docker builds

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -17,7 +17,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ${{ github.repository_owner }}/cache-explorer
   RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
 jobs:
@@ -67,8 +66,10 @@ jobs:
           TAG: ${{ env.RELEASE_TAG }}
         run: |
           image_tag="${TAG#v}"
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          image_prefix="${owner}/cache-explorer"
           for image in sandbox backend frontend; do
-            ref="${REGISTRY}/${IMAGE_PREFIX}-${image}:${image_tag}"
+            ref="${REGISTRY}/${image_prefix}-${image}:${image_tag}"
             echo "Checking ${ref}"
             found=0
             for attempt in $(seq 1 24); do

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM 20 repository
-RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+RUN for attempt in 1 2 3 4 5; do \
+      wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key && break; \
+      if [ "$attempt" -eq 5 ]; then exit 1; fi; \
+      sleep 5; \
+    done \
     && echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list
 
 # Install build dependencies
@@ -76,7 +80,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM 20 repository
-RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+RUN for attempt in 1 2 3 4 5; do \
+      wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key && break; \
+      if [ "$attempt" -eq 5 ]; then exit 1; fi; \
+      sleep 5; \
+    done \
     && echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list
 
 # Install runtime dependencies including opt for bitcode pipeline

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM 20 repository
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list
+RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     clang-20 \
     llvm-20-dev \
     lld-20 \
@@ -75,11 +76,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Add LLVM 20 repository
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list
+RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list
 
 # Install runtime dependencies including opt for bitcode pipeline
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
     clang-20 \
     lld-20 \
     llvm-20 \

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -13,11 +13,18 @@ RUN apt-get update && apt-get install -y \
     lsb-release \
     software-properties-common \
     gnupg \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Install LLVM 20
-RUN apt-get update && wget -qO- https://apt.llvm.org/llvm.sh | bash -s 20
-RUN apt-get install -y llvm-20-dev clang-20 lld-20
+RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+      llvm-20-dev \
+      clang-20 \
+      lld-20 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set LLVM paths
 ENV PATH="/usr/lib/llvm-20/bin:${PATH}"
@@ -74,6 +81,7 @@ RUN apt-get update && apt-get install -y \
     lsb-release \
     software-properties-common \
     gnupg \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20
@@ -81,8 +89,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs
 
 # Install LLVM 20 runtime components
-RUN apt-get update && wget -qO- https://apt.llvm.org/llvm.sh | bash -s 20
-RUN apt-get install -y clang-20
+RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get -o Acquire::Retries=5 install -y --no-install-recommends clang-20 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set LLVM paths
 ENV PATH="/usr/lib/llvm-20/bin:${PATH}"

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -17,7 +17,11 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install LLVM 20
-RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+RUN for attempt in 1 2 3 4 5; do \
+      wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key && break; \
+      if [ "$attempt" -eq 5 ]; then exit 1; fi; \
+      sleep 5; \
+    done \
     && echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list
 RUN apt-get -o Acquire::Retries=5 update \
     && apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
@@ -89,7 +93,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs
 
 # Install LLVM 20 runtime components
-RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+RUN for attempt in 1 2 3 4 5; do \
+      wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key && break; \
+      if [ "$attempt" -eq 5 ]; then exit 1; fi; \
+      sleep 5; \
+    done \
     && echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list
 RUN apt-get -o Acquire::Retries=5 update \
     && apt-get -o Acquire::Retries=5 install -y --no-install-recommends clang-20 \


### PR DESCRIPTION
## Summary
- lowercase the GitHub owner when constructing GHCR validation references
- use direct HTTPS LLVM repositories instead of the installer script's availability probe
- retry LLVM package downloads in sandbox and backend build/runtime stages

## Verification
- parsed the workflow YAML and exercised mixed-case owner normalization
- confirmed the Noble and Jammy LLVM 20 repository metadata and signing-key endpoints return HTTP 200
- confirmed all three v1.7.0 OCI manifests are available at normalized GHCR paths
- full CI, Docker, and Linux/macOS LLVM matrices are running on this PR